### PR TITLE
Add basic querystring parsing logic for devMode

### DIFF
--- a/game-template.html
+++ b/game-template.html
@@ -139,7 +139,7 @@ Game.parameters = new GJS.GameParameters({
     'muteAudio': {initial: false}
 });
 
-var DEV_MODE = (window.location.href.indexOf("?devMode") != -1);
+var DEV_MODE = querystringUtil.get('devMode') !== undefined;
 
 window['start'] = function() {
     var DEBUG_MAIN_LOOP = DEV_MODE && true; // Set to true to allow fast-forwarding main loop with 'f'

--- a/game-threejs-template.html
+++ b/game-threejs-template.html
@@ -158,7 +158,7 @@ Game.parameters = new GJS.GameParameters({
     'muteAudio': {initial: false}
 });
 
-var DEV_MODE = (window.location.href.indexOf("?devMode") != -1);
+var DEV_MODE = querystringUtil.get('devMode') !== undefined;
 
 window['start'] = function() {
     var DEBUG_MAIN_LOOP = DEV_MODE && true; // Set to true to allow fast-forwarding main loop with 'f'

--- a/src/utiljs.js
+++ b/src/utiljs.js
@@ -7,6 +7,7 @@ if (typeof GJS === "undefined") {
 var arrayUtil = {}; // Utilities for working with JS arrays
 var stringUtil = {}; // Utilities for working with JS strings
 var objectUtil = {}; // Utilities for working with JS objects
+var querystringUtil = {}; // Utilities for working with querystring parameters
 
 /**
  * Random function. Prefers using mathUtil.random() if available, falls back to Math.random().
@@ -244,6 +245,32 @@ objectUtil.wrap = function(toWrap, excludeFromForwarding) {
         })(prop);
     }
     return wrapper;
+};
+
+/**
+ * Get the value of the given querystring key else return undefined.
+ * @param {String} key Key to search for in the querystring.
+ * @param {String} [querystring] Querystring to search. If undefined then falls back to window.location.search.
+ * @return {(String|undefined)} Value as a string.
+ */
+querystringUtil.get = function(key, querystring) {
+    querystring = querystring || window.location.search;
+
+    if (querystring.indexOf('?') === 0) {
+        querystring = querystring.substring(1);  // Drop the starting "?"
+    }
+
+    var items = querystring.split('&');
+
+    for (var i = 0; i < items.length; i++) {
+        var item = items[i].split('=');
+
+        if (item[0] === key) {
+            return item[1] || '';
+        }
+    }
+
+    return undefined;
 };
 
 

--- a/unit_tests/utiljs_spec.js
+++ b/unit_tests/utiljs_spec.js
@@ -127,3 +127,21 @@ describe('objectUtil', function() {
         expect(obj.hasOwnProperty('c')).toBe(false);
     });
 });
+
+describe('querystringUtil', function() {
+    var querystring = '?x=1&y=2';
+
+    it('gets a querystring value by the key', function() {
+        expect(querystringUtil.get('x', querystring)).toBe('1');
+        expect(querystringUtil.get('y', querystring)).toBe('2');
+    });
+
+    it('returns undefined when the key is missing', function() {
+        expect(querystringUtil.get('z', querystring)).toBe(undefined);
+    });
+
+    it('returns the empty string when the key has no value', function() {
+        expect(querystringUtil.get('a', '?a&b=1')).toBe('');
+        expect(querystringUtil.get('b', '?a=1&b')).toBe('');
+    });
+});


### PR DESCRIPTION
In development we noticed that checking for `?devMode` in the querystring would not work if the key not the first in the querystring. This PR adds basic utility to parse values from the querystring and uses it for the templates.